### PR TITLE
Fixed free segfault

### DIFF
--- a/src/mc_cpu.c
+++ b/src/mc_cpu.c
@@ -318,7 +318,7 @@ void mc_driver_cpu(mc_grids_t grids, double beta, double h, int* grid_fate, mc_s
     // result - either fraction of nucleated trajectories (itask=0) or comittor(s) (itask=1)
     // also allocate the nucleated array to track which grids have nucleated for itask=0
     float *result;
-    int *nucleated; 
+    int *nucleated = NULL; 
     int result_size;
     if (itask==0) {
       result_size = tot_nsweeps/mag_output_int;

--- a/src/mc_gpu.cu
+++ b/src/mc_gpu.cu
@@ -808,7 +808,7 @@ void mc_driver_gpu(mc_gpu_grids_t grids, double beta, double h, int* grid_fate, 
 
     // result - either fraction of nucleated trajectories at each snapshot (itask=0) or comittor(s) (itask=1)
     float *result;
-    int *nucleated; // only used for itask=0
+    int *nucleated = NULL; // only used for itask=0
     int result_size;
     if (itask==0) {
       result_size = tot_nsweeps/mag_output_int;
@@ -1023,6 +1023,5 @@ void mc_driver_gpu(mc_gpu_grids_t grids, double beta, double h, int* grid_fate, 
       
     if (result) free(result);
     if (nucleated) free(nucleated);
-    if (grid_fate) free(grid_fate);
   
 }


### PR DESCRIPTION
Trying to free `nucleated` when it was not initialised caused a segfault. Fix is setting it to `NULL` at initialisation. Also removed `grid_fate` free since that line was not in the cpu version, and `grid_fate` is provided to the `mc_driver_gpu` function and there are already external frees.